### PR TITLE
Add skipped dates functionality for Stammtisch events

### DIFF
--- a/app/NextStammtisch.tsx
+++ b/app/NextStammtisch.tsx
@@ -1,11 +1,17 @@
 'use client'
 
+import skippedDates from '@/data/skippedStammtisch'
+
 export default function NextStammtisch() {
+  // For testing
+  // const currentDate = new Date('2025-06-02T12:00:00Z')
   const currentDate = new Date()
   const currentMonth = currentDate.getUTCMonth()
   const currentYear = currentDate.getUTCFullYear()
   let nextStammtisch = new Date()
   let nextMonth = 0
+
+  let shouldSkip = false
 
   do {
     // Create date object for 1st of current month
@@ -22,16 +28,30 @@ export default function NextStammtisch() {
     // Set start time to 21:00 UTC which is intentially a bit into the event
     nextStammtisch.setUTCHours(21)
 
-    // Check if this is June 2025 because of ProtocolBerg v2 (month 5, since January is 0)
-    if (nextStammtisch.getUTCFullYear() === 2025 && nextStammtisch.getUTCMonth() === 5) {
-      // Skip June 2025
-      nextMonth++
+    // Check if this month is in the skipped dates list
+    shouldSkip = skippedDates.skippedDates.some(
+      (skipped) =>
+        skipped.year === nextStammtisch.getUTCFullYear() &&
+        skipped.month === nextStammtisch.getUTCMonth()
+    )
+
+    console.log(
+      `shouldSkip: ${shouldSkip}, date: ${nextStammtisch.toLocaleDateString('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })}`
+    )
+
+    if (shouldSkip) {
+      ++nextMonth
       continue
     }
 
     // If Stammtisch already started/passed this month, move to next month
-    nextMonth++
-  } while (nextStammtisch < currentDate)
+    ++nextMonth
+  } while (nextStammtisch < currentDate || shouldSkip)
 
   return (
     <span className="font-medium">

--- a/data/blog/2024/1-what.mdx
+++ b/data/blog/2024/1-what.mdx
@@ -2,7 +2,7 @@
 title: 1) What
 date: 2024-03-26T16:06:04.000Z
 lastmod: 2024-07-04T12:57:33.000Z
-tags: ['ETHBerlin', '04, 'hackathon']
+tags: ['ETHBerlin', '04', 'hackathon']
 authors: ['Franzi', 'Helena']
 images: ['/static/images/2024/banner-3.png']
 ---

--- a/data/skippedStammtisch.js
+++ b/data/skippedStammtisch.js
@@ -1,0 +1,13 @@
+// Skipped Stammtisch dates
+// Months are 0-indexed (0 = January, 11 = December)
+const skippedStammtisch = {
+  skippedDates: [
+    {
+      year: 2025,
+      month: 5, // June
+      reason: 'ProtocolBerg v2',
+    },
+  ],
+}
+
+export default skippedStammtisch


### PR DESCRIPTION
Introduced a new data file to manage skipped Stammtisch dates, specifically for June 2025 due to ProtocolBerg v2. Updated the NextStammtisch component to check against this list and skip the specified dates accordingly.

fix #37