### PR TITLE
Add dwebcamp planning unconference and meetup

### DIFF
--- a/data/dodEvents.ts
+++ b/data/dodEvents.ts
@@ -11,6 +11,16 @@ interface Event {
 
 export const events: Event[] = [
   {
+    title: 'DWeb Camp Unconference + Meetup',
+    date: '2026-02-28',
+    description:
+      'help co-create dwebcamp at the unconference and get inspired and connected at the meetup',
+    link: {
+      url: 'https://dwebcamp.org/berlin-2026/',
+      label: 'dwebcamp.org/berlin-2026',
+    },
+  },
+  {
     title: 'Criticial Decentralization Cluster',
     date: '2025-12-01',
     description:


### PR DESCRIPTION
the times / sorting is a bit suboptimal yet though:
<img width="1291" height="619" alt="image" src="https://github.com/user-attachments/assets/1cbd2181-772f-4c42-95b2-207e7557c1ad" />

so maybe we wait with merging before this is fixed - guess #48 has the same issue
