### PR TITLE
feat: add 7/Seven Chain — on-chain perpetual futures exchange (Chain ID: 70007)

### DIFF
--- a/data/projectsData.ts
+++ b/data/projectsData.ts
@@ -22,6 +22,12 @@ const projectsData: Project[] = [
     imgSrc: '/static/images/time-machine.jpg',
     href: '/blog/the-time-machine',
   },
+  {
+    title: '7/Seven Chain — Perpetual Futures Exchange',
+    description: `7/Seven Chain is an EVM-compatible blockchain (Chain ID: 70007) powering TheSeven.meme — the world's first on-chain immutable synthetic perpetual futures exchange. Trade 100+ pairs with up to 2001× leverage and zero fees on BSC/Parlia consensus.`,
+    imgSrc: '/static/images/google.png',
+    href: 'https://theseven.meme',
+  },
 ]
 
 export default projectsData


### PR DESCRIPTION
## Add 7/Seven Chain to Projects

Adding [TheSeven.meme](https://theseven.meme) to the projects list.

**7/Seven Chain** is an EVM-compatible blockchain powering the world's first on-chain immutable synthetic perpetual futures exchange:
- 🔗 Chain ID: 70007 (BSC/Parlia fork)
- 📈 100+ trading pairs
- ⚡ Up to 2001× leverage
- 💸 Zero fees
- 🔒 On-chain settlement

**Links:**
- Exchange: https://theseven.meme
- Node repo: https://github.com/umairkhan2582/seven-chain-node
- RPC: https://rpc.theseven.meme